### PR TITLE
Add image compression for posts at build time

### DIFF
--- a/posts/performance/index.md
+++ b/posts/performance/index.md
@@ -1,6 +1,6 @@
 ---
 title: Performance Upgrades
-slug: perf-upgrades
+slug: performance
 author: bradygaster
 lastModified: 2017-01-17 12:00:00
 pubDate: 2017-01-17 12:00:00

--- a/posts/performance/index.md
+++ b/posts/performance/index.md
@@ -1,0 +1,14 @@
+---
+title: Performance Upgrades
+slug: perf-upgrades
+author: bradygaster
+lastModified: 2017-01-17 12:00:00
+pubDate: 2017-01-17 12:00:00
+categories: downr, performance
+---
+
+Recent PR(s) by [Shayne Boyer](http://twitter.com/spboyer) have added the following performace upgrades.
+
+1. Compression Middleware to enable gzip
+1. Static Asset caching
+1. Image minification and compression at build time.

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+azure.err
+*.publishsettings

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -18,6 +18,7 @@ namespace downr
                 .Build();
 
             var host = new WebHostBuilder()
+                .CaptureStartupErrors(true)
                 .UseConfiguration(config)
                 .UseKestrel()
                 .UseContentRoot(Directory.GetCurrentDirectory())

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -61,7 +61,6 @@ namespace downr
             }
             else
             {
-                app.UseDeveloperExceptionPage();
                 app.UseExceptionHandler("/Home/Error");
             }
             

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -61,6 +61,7 @@ namespace downr
             }
             else
             {
+                app.UseDeveloperExceptionPage();
                 app.UseExceptionHandler("/Home/Error");
             }
             

--- a/src/gruntfile.js
+++ b/src/gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
             content: {
                 files: [{
                     cwd: '../posts',
-                    src: '**/*.*',
+                    src: ['**/*', '!**/media/**'],
                     dest: 'wwwroot/posts',
                     expand: true
                 }]
@@ -30,14 +30,26 @@ module.exports = function (grunt) {
         clean: {
             posts: 'wwwroot/posts',
             style: 'wwwroot/css'
+        },
+        imagemin: {                            
+            dynamic: {                         
+            files: [{
+                expand: true,                  // Enable dynamic expansion
+                cwd: '../posts',               // Src matches are relative to this path
+                src: ['**/*.{png,jpg,gif}'],   // Actual patterns to match
+                dest: 'wwwroot/posts'          // Destination path prefix
+            }]
+            }
         }
     });
 
-    grunt.registerTask('postpublish', ['clean:posts', 'copy:content']);
+    grunt.registerTask('postpublish', ['clean:posts', 'copy:content', 'imagemin']);
 
     grunt.registerTask('precompile', ['copy:views', 'clean:style', 'copy:style']);
 
     grunt.loadNpmTasks('grunt-contrib-copy');
 
     grunt.loadNpmTasks('grunt-contrib-clean');
+
+    grunt.loadNpmTasks('grunt-contrib-imagemin');
 };

--- a/src/package.json
+++ b/src/package.json
@@ -10,6 +10,7 @@
     "bower": "1.8.0",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-copy": "^1.0.0"
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-imagemin": "^1.0.1"
   }
 }


### PR DESCRIPTION
Added grunt imagemin to minify and compress images during `postbuild` process.  Just on initial **Introducing downr** post.

```
Running "imagemin:dynamic" (imagemin) task
Minified 6 images (saved 222.17 kB)
```

