### PR TITLE
env.WebRootPath is null in my environment

### DIFF
--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -81,6 +81,10 @@ namespace downr
             });
 
             // get the path to the content directory so the yaml headers can be indexed as metadata
+            if (string.IsNullOrWhiteSpace(env.WebRootPath))
+            {
+                env.WebRootPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot");
+            }
             var contentPath = Path.Combine(env.WebRootPath, "posts");
             yamlIndexer.IndexContentFiles(contentPath);
         }


### PR DESCRIPTION
This PR is more to pose the question as to why my plain-vanilla Azure web app deployment of a clean master clone has env.WebRootPath as null. As a result, Path.Combine() throws an exception, which 500s the site.

I set IHostingEnvironment.WebRootPath to within current working directory when null and default pages appear.