### PR TITLE
Add dotnet watch

### DIFF
--- a/src/downr.csproj
+++ b/src/downr.csproj
@@ -27,6 +27,7 @@ dotnet bundle</PreBuildEvent> -->
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0-msbuild3-final" />
+    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0" />
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.2.306" />
   </ItemGroup>
   <!-- <Target Name="PrepublishScript" BeforeTargets="Publish" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">


### PR DESCRIPTION
Add dotnet-watch tool for easier dev flow in VSCode

Now use `dotnet watch run` instead of `dotnet run` to have dotnet rebuild and rerun the code on file changes