### PR TITLE
Fixed error with VS 2017 build

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,8 +1,4 @@
-dotnet restore
-cd src
-npm install
-bower install
-grunt precompile
+:: dotnet build runs a build on downr.proj
+:: inside downr.proj a pre build task (pre-build.cmd) and post build task (post-build.bat) is defined
+
 dotnet build
-grunt postpublish
-dotnet bundle

--- a/downr.sln
+++ b/downr.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "downr", "src\downr.csproj", "{2D65D372-F196-4886-BDBA-97EDAAE1039F}"
 EndProject

--- a/post-build.bat
+++ b/post-build.bat
@@ -1,0 +1,4 @@
+cd src
+grunt postpublish
+dotnet bundle
+cd ..

--- a/pre-build.bat
+++ b/pre-build.bat
@@ -1,0 +1,6 @@
+dotnet restore
+cd src
+npm install
+bower install
+grunt precompile
+cd ..

--- a/src/downr.csproj
+++ b/src/downr.csproj
@@ -5,6 +5,10 @@
   <PropertyGroup>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+    <PreBuildEvent>cd $(SolutionDir)
+call pre-build.bat</PreBuildEvent>
+    <PostBuildEvent>cd $(SolutionDir)
+call post-build.bat</PostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack.NetCore" Version="1.5.0.1" />
@@ -20,7 +24,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />
-    <PackageReference Include="BundlerMinifier.Core" Version="2.3.327"/>
+    <PackageReference Include="BundlerMinifier.Core" Version="2.3.327" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0-msbuild3-final" />


### PR DESCRIPTION
It was not possible to use downr with VS2017 because the pre-build task were ignored.
Added two script files to fixed this behavior. Now build of VS2017 works the same way like CLI before.